### PR TITLE
passing integration test for chowning all a user's data

### DIFF
--- a/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
+++ b/components/blitz/resources/ome/services/graph-rules/blitz-chown-rules.xml
@@ -285,9 +285,10 @@
 
         <bean parent="graphPolicyRule" p:matches="A:FileAnnotation[E].file = OF:[I]" p:error="may not give {OF} while used by {A}"/>
 
-        <!-- If both parent and child are given then give the annotation link regardless of permissions. -->
+        <!-- If both parent and child are given then give the annotation link unless owned by a third party. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[ED].parent = [I], L.child = [I]" p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:IAnnotationLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
 
         <!-- If an annotation link's parent or child is deleted then delete the link regardless of permissions. -->
 
@@ -354,26 +355,18 @@
         <bean parent="graphPolicyRule" p:matches="F:Folder[E]{o}/o" p:changes="F:[I]"/>
 
         <!--
-             If a project, dataset, folder, image or ROI is given for both sides of a link then, regardless of permissions, give the
-             link if same owners or not in private group.
+             If a project, dataset, folder, image or ROI is given for both sides of a link then give the link unless owned by a
+             third party.
           -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent = P:[I], L.child = D:[I], P =/o D"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent = D:[I], L.child = I:[I], D =/o I"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = F:[I], L.child = I:[I], F =/o I"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = F:[I], L.child = ROI:[I], F =/o ROI"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[E].parent = [I];perms=??r???, L.child = [I]"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[E].parent = [I];perms=??r???, L.child = [I]"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = [I];perms=??r???, L.child = [I]"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = [I];perms=??r???, L.child = [I]"
-                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ProjectDatasetLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:DatasetImageLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderImageLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:FolderRoiLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
 
         <!--
              If a project, dataset, folder, image or ROI is given then delete any remaining cross-owner links regardless of
@@ -683,15 +676,10 @@
         <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [E]{ia}, L.child = P:[E]{r}" p:changes="P:{a}"/>
         <bean parent="graphPolicyRule" p:matches="P:Plate[E]{o}" p:changes="P:[I]"/>
 
-        <!--
-             If a screen and plate are given for both sides of a link then, regardless of permissions, give the link if same owners
-             or not to private group.
-          -->
+        <!-- If a screen and plate are given for both sides of a link then give the link unless owned by a third party. -->
 
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[ED].parent = S:[I], L.child = P:[I], S =/o P"
-                                       p:changes="L:[I]/n"/>
-        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[E].parent = [I];perms=??r???, L.child = [I]"
-                                       p:changes="L:[I]/n"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[ED].parent =/o [I], L.child = [I]" p:changes="L:[I]"/>
+        <bean parent="graphPolicyRule" p:matches="L:ScreenPlateLink[ED].parent = [I], L.child =/o [I]" p:changes="L:[I]"/>
 
         <!-- If a screen or plate are given then delete their remaining links regardless of permissions in a private group. -->
 

--- a/components/blitz/src/omero/cmd/graphs/Chown2I.java
+++ b/components/blitz/src/omero/cmd/graphs/Chown2I.java
@@ -156,6 +156,21 @@ public class Chown2I extends Chown2 implements IRequest, WrappableRequest<Chown2
             final IAdmin iAdmin = helper.getServiceFactory().getAdminService();
             acceptableGroupsFrom = ImmutableSet.copyOf(eventContext.getLeaderOfGroupsList());
             acceptableGroupsTo = ImmutableSet.copyOf(iAdmin.getMemberOfGroupIds(new Experimenter(userId, false)));
+            if (acceptableGroupsFrom.isEmpty()) {
+                throw new RuntimeException(new GraphException("not an owner of any group"));
+            }
+            if (targetUsers != null) {
+                for (final Long targetUserId : targetUsers) {
+                    final Set<Long> groupsForTargetUserData = new HashSet<Long>(acceptableGroupsFrom);
+                    final Experimenter targetUser = new Experimenter(targetUserId, false);
+                    groupsForTargetUserData.retainAll(iAdmin.getMemberOfGroupIds(targetUser));
+                    if (groupsForTargetUserData.isEmpty()) {
+                        final String message = "not an owner of any group of " +
+                                Experimenter.class.getName() + "[" + targetUserId + "]";
+                        throw new RuntimeException(new GraphException(message));
+                    }
+                }
+            }
         }
 
         graphPolicy.registerPredicate(new PermissionsPredicate());

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -594,6 +594,7 @@ public class PermissionsTest extends AbstractServerTest {
             }
         }
         /* create two tag sets and three tags */
+        init(importerTargetUser);
         final List<TagAnnotation> tagsets = createTagsets(2);
         final List<TagAnnotation> tags = createTags(3);
 
@@ -603,7 +604,7 @@ public class PermissionsTest extends AbstractServerTest {
 
         /* chown all what belongs to importerTargetUser to recipient */
 
-        init(importerTargetUser);
+        init(chowner);
         Chown2 chown = Requests.chown().targetUsers(importerTargetUser.userId).toUser(recipient.userId).build();
         doChange(client, factory, chown, isExpectSuccess);
 

--- a/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
+++ b/components/tools/OmeroJava/test/integration/chown/PermissionsTest.java
@@ -1022,7 +1022,7 @@ public class PermissionsTest extends AbstractServerTest {
         logRootIntoGroup(dataGroupId);
         assertOwnedBy(container, recipient);
         assertOwnedBy(image, isImageOwner ? recipient : imageOwner);
-        assertOwnedBy(link, isImageOwner ? recipient : linkOwner);
+        assertOwnedBy(link, isImageOwner && isLinkOwner ? recipient : linkOwner);
     }
 
     /**


### PR DESCRIPTION
1. Fixes the new chown test's user-switching to that created object instances have the correct ownership.
2. Fixes `Chown2` to _not_ implicitly chown a link owned by a third party. E.g., if Alice tags Bob's image with Bob's tag then chown should _not_ give Alice's link when giving Bob's data.
3. Increases `Chown2`'s error-checking for hopeless attempts at giving data.
